### PR TITLE
perf: prefer CMAKE_CURRENT_BINARY_DIR

### DIFF
--- a/cmake/install/Common.cmake
+++ b/cmake/install/Common.cmake
@@ -98,7 +98,8 @@ function(install_target)
     DESTINATION share/${arg_NAME}
     COMPONENT ${arg_NAME}_development)
 
-  set(_cache_dir ${CMAKE_BINARY_DIR}/${CMAKE_CURRENT_FUNCTION}/${arg_NAME})
+  set(_cache_dir
+      ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CURRENT_FUNCTION}/${arg_NAME})
 
   if(NOT arg_CONFIGURE_PACKAGE_CONFIG_FILE)
 


### PR DESCRIPTION
Previously, it was easy to cause confusion by placing the generated install export files in the build root directory. Now it is more reasonable to place them in the corresponding build source directory.

Close #10