### PR TITLE
perf: optimize generate_git_header

### DIFF
--- a/cmake/configure/GitTools.cmake
+++ b/cmake/configure/GitTools.cmake
@@ -55,6 +55,14 @@ function(generate_git_header)
   endif()
 
   if(NOT arg_CONFIGURE_HEADER_FILE)
+
+    # Define default template variables
+    if(NOT CMAKE_PROJECT_GIT_COMMIT_DIRTY)
+      set(CMAKE_PROJECT_GIT_COMMIT_DIRTY
+          0
+          CACHE INTERNAL "")
+    endif()
+
     set(_configure_git_header_content
         "#pragma once
 // git.h


### PR DESCRIPTION
When CMAKE_PROJECT_GIT_COMMIT_DIRTY is not defined, it means there's nothing changed by default